### PR TITLE
Allow last_variable_index_ to be zero

### DIFF
--- a/ortools/linear_solver/cplex_interface.cc
+++ b/ortools/linear_solver/cplex_interface.cc
@@ -863,7 +863,8 @@ void CplexInterface::ExtractNewConstraints() {
 
     CPXDIM newCons = total - offset;
     CPXDIM const cols = CPXXgetnumcols(mEnv, mLp);
-    DCHECK_EQ(last_variable_index_, cols);
+    CHECK(last_variable_index_ == 0 ||
+          last_variable_index_ == cols);
     CPXDIM const chunk = 10;  // max number of rows to add in one shot
 
     // Update indices of new constraints _before_ actually extracting
@@ -950,7 +951,8 @@ void CplexInterface::ExtractObjective() {
   //       any non-zero duplicates.
 
   CPXDIM const cols = CPXXgetnumcols(mEnv, mLp);
-  DCHECK_EQ(last_variable_index_, cols);
+  CHECK(last_variable_index_ == 0 ||
+        last_variable_index_ == cols);
 
   unique_ptr<CPXDIM[]> ind(new CPXDIM[cols]);
   unique_ptr<double[]> val(new double[cols]);


### PR DESCRIPTION
<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->
Fix for https://github.com/google/or-tools/issues/3757